### PR TITLE
moving tagged devices to their own ssh rules

### DIFF
--- a/network/policy.hujson
+++ b/network/policy.hujson
@@ -28,7 +28,7 @@
 			"users":  ["autogroup:nonroot"],
 		},
 		{
-			"action": "allow",
+			"action": "accept",
 			"src":    ["tag:lab"],
 			"dst":    ["tag:lab"],
 			"users":  ["arden"],

--- a/network/policy.hujson
+++ b/network/policy.hujson
@@ -27,5 +27,12 @@
 			"dst":    ["autogroup:self"],
 			"users":  ["autogroup:nonroot"],
 		},
+		{
+			"action": "allow",
+			"src":    ["tag:lab"],
+			"dst":    ["tag:lab"],
+			"users":  ["arden"],
+		},
+
 	]
 }


### PR DESCRIPTION
because you can't use check mode with tagged devices
